### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Learning content
+* @nodejs/nodejs-website
+
+# Repository infrastructure
+.github/ @nodejs/web-infra
+doc-kit.config.mjs @nodejs/web-infra
+package.json @nodejs/nodejs-website @nodejs/web-infra
+package-lock.json @nodejs/web-infra
+vercel.json @nodejs/web-infra


### PR DESCRIPTION
## Description

Adds a repository-level `CODEOWNERS` file so content and infrastructure changes automatically request the appropriate Node.js teams for review.

## Changes

- add a default owner for repository content
- route `.github` and deployment/tooling files to `@nodejs/web-infra`
- keep `package.json` shared between website and infra owners

Fixes #9
