### PR TITLE
fix: broken internal links

### DIFF
--- a/pages/diagnostics/live-debugging/using-inspector.md
+++ b/pages/diagnostics/live-debugging/using-inspector.md
@@ -9,4 +9,4 @@ of the application as it handles a business-critical workload.
 
 ## How To
 
-[Debugging Node.js](/learn/diagnostics/debugging)
+[Debugging Node.js](/learn/getting-started/debugging)

--- a/pages/diagnostics/poor-performance/index.md
+++ b/pages/diagnostics/poor-performance/index.md
@@ -22,5 +22,5 @@ the others. When we do this locally, we usually try to optimize our code.
 
 This document provides two simple ways to profile a Node.js application:
 
-- [Using V8 Sampling Profiler](/learn/diagnostics/profiling)
+- [Using V8 Sampling Profiler](/learn/getting-started/profiling)
 - [Using Linux Perf](/learn/diagnostics/poor-performance/using-linux-perf)

--- a/pages/getting-started/profiling.md
+++ b/pages/getting-started/profiling.md
@@ -288,4 +288,4 @@ You may also find [how to create a flame graph][diagnostics flamegraph] helpful.
 
 [profiler inside V8]: https://v8.dev/docs/profile
 [benefits of asynchronous programming]: https://nodesource.com/blog/why-asynchronous
-[diagnostics flamegraph]: /diagnostics/flame-graphs
+[diagnostics flamegraph]: /learn/diagnostics/flame-graphs

--- a/pages/getting-started/security-best-practices.md
+++ b/pages/getting-started/security-best-practices.md
@@ -459,8 +459,8 @@ You can also collaborate with other projects and security experts through the [O
 [Slowloris]: https://en.wikipedia.org/wiki/Slowloris_(computer_security)
 [`http.Server`]: https://nodejs.org/api/http.html#class-httpserver
 [http docs]: https://nodejs.org/api/http.html
-[--inspect switch]: /diagnostics/debugging
-[same-origin policy]: /diagnostics/debugging
+[--inspect switch]: /learn/getting-started/debugging
+[same-origin policy]: /learn/getting-started/debugging
 [DNS Rebinding wiki]: https://en.wikipedia.org/wiki/DNS_rebinding
 [files property]: https://docs.npmjs.com/cli/configuring-npm/package-json#files
 [unpublish the package]: https://docs.npmjs.com/unpublishing-packages-from-the-registry

--- a/pages/modules/how-to-use-streams.md
+++ b/pages/modules/how-to-use-streams.md
@@ -829,7 +829,7 @@ This work is derived from content published by [Matteo Collina][] in [Platformat
 [`WritableStream`]: https://nodejs.org/api/webstreams.html#class-writablestream
 [`TransformStream`]: https://nodejs.org/api/webstreams.html#class-transformstream
 [`WHATWG Streams Standard`]: https://streams.spec.whatwg.org/
-[`backpressure guide`]: /asynchronous-work/backpressuring-in-streams
+[`backpressure guide`]: /learn/modules/backpressuring-in-streams
 [`fs.readStream`]: https://nodejs.org/api/fs.html#class-fsreadstream
 [`http.IncomingMessage`]: https://nodejs.org/api/http.html#class-httpincomingmessage
 [`process.stdin`]: https://nodejs.org/api/process.html#processstdin


### PR DESCRIPTION
As stated in the title, this PR updates the links that were leading to 404 pages on the edited pages with their correct versions.

Pages and links;
- /learn/diagnostics/live-debugging/using-inspector
    - `Debugging Node.js`
- /learn/diagnostics/poor-performance/index
    - `Using V8 Sampling Profiler` 
- /learn/getting-started/profiling
    - `diagnostics flamegraph`
- /learn/getting-started/security-best-practices
    - `--inspect switch`
    - `same-origin policy`
- /learn/modules/how-to-use-streams
    - `backpressure guide` 