### PR TITLE
fix: update the `download` navigation link from `/download` to `/en/download`

### DIFF
--- a/site.json
+++ b/site.json
@@ -9,7 +9,7 @@
       "text": "About"
     },
     {
-      "link": "/download",
+      "link": "/en/download",
       "text": "Download"
     },
     {


### PR DESCRIPTION
Update the download navigation link so that it points to `<root>/en/download` (which is the correct page it should point to) instead of pointing to `<root>/download` (which contains the raw download directory listing instead)