### PR TITLE
docs: update broken MDN link for asynchronous programming

### DIFF
--- a/pages/getting-started/how-much-javascript-do-you-need-to-know-to-use-nodejs.md
+++ b/pages/getting-started/how-much-javascript-do-you-need-to-know-to-use-nodejs.md
@@ -30,7 +30,7 @@ With those concepts in mind, you are well on your road to become a proficient Ja
 
 The following concepts are also key to understand asynchronous programming, which is one of the fundamental parts of Node.js:
 
-- [Asynchronous programming and callbacks](https://developer.mozilla.org/en-US/docs/JavaScript/Asynchronous/Introducing)
+- [Asynchronous programming and callbacks](https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Async_JS/Introducing)
 - [Timers](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout)
 - [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)
 - [Async and Await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)


### PR DESCRIPTION
### Description
This PR fixes a broken MDN Web Docs link in the "How much JavaScript do you need to know to use Node.js?" getting-started guide.

**The Issue:**
In the "Asynchronous Programming" section, the link for "Asynchronous programming and callbacks" points to `https://developer.mozilla.org/en-US/docs/JavaScript/Asynchronous/Introducing`, which currently returns a 404 Page Not Found due to MDN restructuring their learning paths. 

**The Fix:**
Updated the URL to point to the correct, newly relocated MDN article: `https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Async_JS/Introducing`.

### Type of Change
- [x] Documentation update / Link fix