### PR TITLE
docs: add --min-release-age as supply chain mitigation

### DIFF
--- a/pages/getting-started/security-best-practices.md
+++ b/pages/getting-started/security-best-practices.md
@@ -270,6 +270,19 @@ Possible attack vectors:
   in favor of _package.json_).
 - Carefully check the _package.json_ file for errors/typos in the names of the
   dependencies.
+- Set a dependency cooldown with [`--min-release-age`][min-release-age]
+  (npm v11.10.0+) to avoid installing recently published packages.
+  The value is in days (e.g., `1` means packages must be at least one day
+  old). Most compromised packages are detected and removed within hours.
+  A cooldown of even one day eliminates exposure to the majority of
+  short-lived supply chain attacks:
+  ```ini
+  min-release-age=1
+  ```
+  To apply security fixes without waiting for the cooldown, override it
+  per-command: `npm install package-name --min-release-age=0`. Use
+  `npm audit` to identify packages with known vulnerabilities that need
+  immediate updates.
 
 ### Memory Access Violation (CWE-284)
 
@@ -485,3 +498,4 @@ You can also collaborate with other projects and security experts through the [O
 [OpenSSF Scorecard]: https://securityscorecards.dev/
 [OpenSSF Best Practices Badge Program]: https://bestpractices.coreinfrastructure.org/en
 [OpenJS Security Collaboration Space]: https://github.com/openjs-foundation/security-collab-space
+[min-release-age]: https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age


### PR DESCRIPTION
Add dependency cooldown (--min-release-age, npm v11.10.0+) to the supply chain attack mitigations in the security best practices guide. Recommend a 1-day cooldown as the minimum effective value.

Every major npm supply chain incident in 2025-2026 had an exposure window well under 24 hours, making even a 1-day delay sufficient:

- Nx/s1ngularity (Aug 2025): ~4-5h window https://nx.dev/blog/s1ngularity-postmortem
- Shai-Hulud (Sep 2025): hours before detection https://www.wiz.io/blog/shai-hulud-npm-supply-chain-attack
- axios (Mar 2026): ~2-3h window, 100M weekly downloads https://workos.com/blog/axios-npm-supply-chain-attack
- TanStack (May 2026): ~30 min window, 42 packages https://tanstack.com/blog/npm-supply-chain-compromise-postmortem

Other projects also propose cooldown as a mitigation:

pnpm 11 ships with minimumReleaseAge enabled by default (1 day): https://pnpm.io/blog/releases/11.0

StepSecurity Secure Registry offers a configurable cooldown and confirmed their customers were unaffected during the May 2026 @antv compromise:
https://www.stepsecurity.io/blog/introducing-secure-registry-install-time-defense-for-the-npm-supply-chain