### PR TITLE
docs(asynchronous-work): fix misaligned event loop ASCII diagram and add warning for changes to diagram alignment

### DIFF
--- a/pages/asynchronous-work/event-loop-timers-and-nexttick.md
+++ b/pages/asynchronous-work/event-loop-timers-and-nexttick.md
@@ -22,29 +22,36 @@ this document) which may make async API calls, schedule timers, or call
 The following diagram shows a simplified overview of the event loop's
 order of operations.
 
+<!--
+  NOTE: This diagram may appear misaligned in the markdown source,
+  but it renders correctly in the HTML view on the live page.
+  Future contributors: please do not adjust the alignment here
+  unless it is also broken on a live page.
+-->
+
 ```
    ┌───────────────────────────┐
-   │           timers          │
+   │          timers         │
    └─────────────┬─────────────┘
-                 │
-                 v
+                │
+                v
    ┌───────────────────────────┐
-┌─>│     pending callbacks     │
+┌─>│     pending callbacks   │
 │  └─────────────┬─────────────┘
 │  ┌─────────────┴─────────────┐
-│  │       idle, prepare       │
-│  └─────────────┬─────────────┘      ┌───────────────┐
+│  │       idle, prepare     │
+│  └─────────────┬─────────────┘      ┌────────────────┐
 │  ┌─────────────┴─────────────┐      │   incoming:   │
-│  │           poll            │<─────┤  connections, │
+│  │           poll          │<─────┤  connections, │
 │  └─────────────┬─────────────┘      │   data, etc.  │
-│  ┌─────────────┴─────────────┐      └───────────────┘
-│  │           check           │
+│  ┌─────────────┴─────────────┐      └────────────────┘
+│  │           check         │
 │  └─────────────┬─────────────┘
 │  ┌─────────────┴─────────────┐
-│  │      close callbacks      │
+│  │      close callbacks    │
 │  └─────────────┬─────────────┘
 │  ┌─────────────┴─────────────┐
-└──┤           timers          │
+└──┤           timers        │
    └───────────────────────────┘
 ```
 


### PR DESCRIPTION
## Summary

This PR adjusts the event loop ASCII diagram in the markdown source so its spacing and alignment render correctly on the live docs page.

## Changes

- update the ASCII diagram in `pages/asynchronous-work/event-loop-timers-and-nexttick.md` to reflect proper alignment
- add a contributor note explaining that the raw markdown may look slightly off while still rendering correctly in the generated HTML

## Why

The event loop diagram is whitespace-sensitive, and small formatting changes can make it look misaligned in source or in the rendered page. This change preserves the intended layout and documents that behavior for future contributors. Without this note, there is a risk that well-intentioned contributors might attempt to "fix" the alignment in the `.md` file, which would actually break the visual layout for end-users. 

This note serves as a safeguard to preserve the correct live rendering.

## Verification

- reviewed the markdown source formatting
- verified the generated HTML renders the diagram correctly

Current View:

<img width="1172" height="889" alt="image" src="https://github.com/user-attachments/assets/14b126f4-cfa7-4378-add6-ed0f1eac8131" />


Fixed View:

<img width="1184" height="939" alt="image" src="https://github.com/user-attachments/assets/218dead6-f4aa-43a7-8acd-84bf9cf6779a" />

