### PR TITLE
Correct Node.js version for custom CA trust

### DIFF
--- a/pages/http/enterprise-network-configuration.md
+++ b/pages/http/enterprise-network-configuration.md
@@ -188,7 +188,7 @@ By default, Node.js uses Mozilla’s bundled root CAs and does not consult the O
 Error: self signed certificate in certificate chain
 ```
 
-From Node.js v22.15.0, v23.9.0, v24.0.0 and above, Node.js can be configured to trust these custom CAs using the system's certificate store.
+From Node.js v22.19.0, v24.6.0 and above, Node.js can be configured to trust these custom CAs using the system's certificate store.
 
 ### Adding CA Certificates from the System Store
 


### PR DESCRIPTION
22.15 doesn't really support NODE_USE_SYSTEM_CA=1, only 22.19 does, it was tested and it is already documented in https://nodejs.org/api/cli.html#node_use_system_ca1