### PR TITLE
Fix code block font for event loop diagram

### DIFF
--- a/template.html
+++ b/template.html
@@ -34,6 +34,12 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Open+Sans:ital,wght@0,300..800;1,300..800"
     />
+    <style>
+      main pre code {
+        font-family: var(--font-mono);
+        font-weight: var(--font-weight-regular);
+      }
+    </style>
 
     <!-- Apply theme before paint to avoid Flash of Unstyled Content -->
     <script>


### PR DESCRIPTION
Uses the monospace stack for rendered code blocks so box-drawing diagrams stay aligned in Chrome.

Fixes #36.

Checks:
- npm.cmd run format:check
- npm.cmd run lint
- npm.cmd run build
- local browser check for the event loop page