### PR TITLE
fix: typo "Contibute" → "Contribute" in site.json navigation

### DIFF
--- a/site.json
+++ b/site.json
@@ -22,7 +22,7 @@
     },
     {
       "link": "https://github.com/nodejs/node/blob/main/CONTRIBUTING.md",
-      "text": "Contibute",
+      "text": "Contribute",
       "target": "_blank"
     },
     {


### PR DESCRIPTION
Fixed a spelling typo in the navigation bar.
"Contibute" → "Contribute"