### PR TITLE
docs(asynchronous-work): clarify setTimeout() scheduling in process.nextTick guide

### DIFF
--- a/pages/asynchronous-work/understanding-processnexttick.md
+++ b/pages/asynchronous-work/understanding-processnexttick.md
@@ -19,7 +19,7 @@ The event loop is busy processing the current function code. When this operation
 
 It's the way we can tell the JS engine to process a function asynchronously (after the current function), but as soon as possible, not queue it.
 
-Calling `setTimeout(() => {}, 0)` will execute the function at the end of next tick, much later than when using `nextTick()` which prioritizes the call and executes it just before the beginning of the next tick.
+Calling `setTimeout(() => {}, 0)` schedules the callback for a future event loop iteration, much later than when using `process.nextTick()`, which executes before the event loop continues.
 
 Use `nextTick()` when you want to make sure that in the next event loop iteration that code is already executed.
 

--- a/site.json
+++ b/site.json
@@ -22,7 +22,7 @@
     },
     {
       "link": "https://github.com/nodejs/node/blob/main/CONTRIBUTING.md",
-      "text": "Contibute",
+      "text": "Contribute",
       "target": "_blank"
     },
     {


### PR DESCRIPTION
## Summary

This change clarifies the wording describing `setTimeout(() => {}, 0)` in the `Understanding process.nextTick()` guide.

The previous wording referred to the callback executing "at the end of next tick", which may be interpreted as a specific event loop timing. The updated wording instead describes it as being scheduled for a future event loop iteration while preserving the beginner-friendly explanation.

No behavioral changes are introduced.