### PR TITLE
docs: clarify timer execution order after libuv 1.45.0

### DIFF
--- a/pages/asynchronous-work/event-loop-timers-and-nexttick.md
+++ b/pages/asynchronous-work/event-loop-timers-and-nexttick.md
@@ -89,10 +89,12 @@ Between each run of the event loop, Node.js checks if it is waiting for
 any asynchronous I/O or timers and shuts down cleanly if there are not
 any.
 
-Starting with libuv 1.45.0 (Node.js 20), the event loop behavior
-changed to run timers only after the **poll** phase, instead of both before and after
-as in earlier versions. This change can affect the timing of `setImmediate()` callbacks
-and how they interact with timers in certain scenarios.
+Starting with libuv 1.45.0 (Node.js 20), timers are run after the
+**poll** phase in each event loop iteration. In earlier versions, timers
+were run before polling. To preserve backwards compatibility, libuv
+1.45.0 still runs timers once before entering the event loop . This change can affect the timing of
+`setImmediate()` callbacks and how they interact with timers in certain
+scenarios.
 
 ## Phases in Detail
 


### PR DESCRIPTION
  The previous wording said that timers now run only after the `poll` phase,
  "instead of both before and after" as in earlier versions. That phrasing can
  be misleading because it sounds like earlier libuv versions ran timers twice
  during a normal event loop iteration: once before polling and once after
  polling.

  Looking at the actual libuv code, the behavior is more precise:

  Before libuv 1.45.0, the regular `UV_RUN_DEFAULT` path ran timers near the
  beginning of each loop iteration, before polling:

  ```c
  while (...) {
    uv__update_time(loop);
    uv__run_timers(loop);

    ...
    uv__io_poll(loop, timeout);
    ...
  }
  ```
  There was a post-poll timer run only for the UV_RUN_ONCE special case, not for
  the normal UV_RUN_DEFAULT path used by Node.js' main event loop.

  Starting with libuv 1.45.0, the regular per-iteration timer processing was
  moved to after polling:
  ```c
  while (...) {
    ...
    uv__io_poll(loop, timeout);
    ...
    uv__update_time(loop);
    uv__run_timers(loop);
  }
  ```
  libuv 1.45.0 also keeps a compatibility behavior for UV_RUN_DEFAULT: it runs
  timers once before entering the uv_run() loop. This preserves backwards
  compatibility while still making the per-iteration timer ordering happen after
  the poll phase.

