### PR TITLE
docs: add Concurrency section comparing child_process, worker_threads, and cluster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ All articles live under `pages/`, organized into topic sections:
 | --------------------- | ------------------------------------------------------- |
 | `getting-started/`    | Introduction, V8 engine, dev vs production, WebAssembly |
 | `asynchronous-work/`  | Event loop, callbacks, promises, streams                |
+| `concurrency/`        | Child process, worker threads, cluster                  |
 | `command-line/`       | REPL, environment variables, CLI I/O                    |
 | `diagnostics/`        | Debugging, profiling, memory, performance               |
 | `file-system/`        | File paths, stats, reading, writing, folders            |

--- a/pages/concurrency/comparing-nodejs-concurrency-models.md
+++ b/pages/concurrency/comparing-nodejs-concurrency-models.md
@@ -11,7 +11,7 @@ It's a poor fit for two other situations, though:
 - **CPU-bound work** (image resizing, hashing, parsing huge payloads) ties up the single thread and makes your whole application unresponsive while it runs.
 - **Scaling across CPU cores** — a single Node.js process only ever uses one core for its JavaScript, no matter how many cores the machine has.
 
-Node.js ships three built-in modules to address this: [`child_process`](https://nodejs.org/api/child_process.html), [`worker_threads`](https://nodejs.org/api/worker_threads.html), and [`cluster`](https://nodejs.org/api/cluster.html). They solve overlapping problems in different ways, which is why it's easy to reach for the wrong one. This guide compares them side by side and walks through when to use each.
+Node.js ships three built-in modules to address this: [`node:child_process`](https://nodejs.org/api/child_process.html), [`node:worker_threads`](https://nodejs.org/api/worker_threads.html), and [`node:cluster`](https://nodejs.org/api/cluster.html). They solve overlapping problems in different ways, which is why it's easy to reach for the wrong one. This guide compares them side by side and walks through when to use each.
 
 ## The three options at a glance
 

--- a/pages/concurrency/comparing-nodejs-concurrency-models.md
+++ b/pages/concurrency/comparing-nodejs-concurrency-models.md
@@ -2,7 +2,7 @@
 authors: omscse
 ---
 
-# Comparing Node.js concurrency models: Child Process, Worker Threads, and Cluster
+# Comparing Node.js concurrency models
 
 Node.js runs your JavaScript on a single thread, driven by the [event loop](/learn/asynchronous-work/event-loop-timers-and-nexttick). That model is great for I/O-bound work — reading files, querying a database, handling HTTP requests — because Node hands off the waiting to the operating system and keeps the thread free.
 

--- a/pages/concurrency/comparing-nodejs-concurrency-models.md
+++ b/pages/concurrency/comparing-nodejs-concurrency-models.md
@@ -15,11 +15,11 @@ Node.js ships three built-in modules to address this: [`child_process`](https://
 
 ## The three options at a glance
 
-|                  | Runs                                   | Isolation                                 | Communication                                             | Best for                                                                        |
-| ---------------- | -------------------------------------- | ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `child_process`  | A separate OS process (any executable) | Fully isolated, separate memory           | stdio streams, or IPC channel with `fork()`               | Running external programs, or another Node.js script that needs its own process |
-| `worker_threads` | A separate thread, same OS process     | Isolated by default, memory can be shared | `postMessage()`, or shared memory via `SharedArrayBuffer` | CPU-bound JavaScript that would otherwise block the event loop                  |
-| `cluster`        | Multiple full Node.js processes        | Fully isolated, separate memory           | IPC channel (built on `child_process`)                    | Scaling a network server (typically HTTP) across CPU cores                      |
+|                  | Runs               | Memory    | Talks via                | Best for                      |
+| ---------------- | ------------------ | --------- | ------------------------ | ----------------------------- |
+| `child_process`  | Separate process   | Isolated  | stdio, or IPC (`fork()`) | Running external programs     |
+| `worker_threads` | Separate thread    | Shareable | `postMessage()`          | CPU-bound JS work             |
+| `cluster`        | Multiple processes | Isolated  | IPC                      | Scaling a server across cores |
 
 A useful way to tell them apart: `cluster` is built on top of `child_process` specifically to solve the "scale a server across cores" problem, while `worker_threads` exists to solve the "run CPU-heavy code without blocking" problem without paying the cost of a whole new process.
 
@@ -29,12 +29,12 @@ Use `child_process` when you need to run another program — a shell command, a 
 
 ### `spawn`, `exec`, `execFile`, and `fork`
 
-| Method       | Description                                                                             | Use case                                                          |
-| ------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `spawn()`    | Launches a command and exposes stdout/stderr as streams                                 | Long-running processes, or output too large to buffer             |
-| `exec()`     | Runs a command through a shell and buffers the full output                              | Short commands with small output                                  |
-| `execFile()` | Like `exec()`, but runs a file directly without spawning a shell                        | Running a known binary/script safely, without shell interpolation |
-| `fork()`     | A specialized `spawn()` for running another Node.js module, with a built-in IPC channel | Parent/child communication between two Node.js processes          |
+| Method       | Description                                  | Use case                       |
+| ------------ | -------------------------------------------- | ------------------------------ |
+| `spawn()`    | Streams stdout/stderr                        | Long-running, large output     |
+| `exec()`     | Buffers full output via a shell              | Short commands, small output   |
+| `execFile()` | Like `exec()`, no shell                      | Running a known binary safely  |
+| `fork()`     | `spawn()` + built-in IPC for Node.js modules | Parent/child Node.js messaging |
 
 `exec()` buffers the child's entire stdout/stderr in memory and only calls back once the process exits, with the result capped at 1 MiB (`maxBuffer`) by default — trying to capture a large or unbounded output this way will truncate it and terminate the child. `execFile()` avoids spawning a shell entirely, which also sidesteps shell-injection risks when part of the command comes from user input.
 
@@ -93,12 +93,12 @@ process.on('message', msg => {
 
 `worker_threads` was added to let you run JavaScript in parallel, in threads within the _same_ process, specifically to move CPU-bound work off the main thread without blocking it. Unlike `child_process`, workers share the same process — no OS-level process to spin up, and no fully separate memory space.
 
-|                  | Worker Threads                                         | Child Process                     |
-| ---------------- | ------------------------------------------------------ | --------------------------------- |
-| Context          | Same process                                           | Separate process                  |
-| Memory           | Isolated by default; can share via `SharedArrayBuffer` | Fully isolated                    |
-| Startup overhead | Low                                                    | Higher                            |
-| Communication    | `postMessage()` (structured clone, fast)               | stdio or IPC (serialized, slower) |
+|                  | Worker Threads                    | Child Process         |
+| ---------------- | --------------------------------- | --------------------- |
+| Context          | Same process                      | Separate process      |
+| Memory           | Shareable via `SharedArrayBuffer` | Isolated              |
+| Startup overhead | Low                               | Higher                |
+| Communication    | `postMessage()` (fast)            | stdio or IPC (slower) |
 
 ### Example: offloading CPU-bound work
 
@@ -106,7 +106,9 @@ process.on('message', msg => {
 // main.js
 const { Worker } = require('node:worker_threads');
 
-const worker = new Worker('./hash-worker.js', { workerData: 'user-password' });
+const worker = new Worker('./hash-worker.js', {
+  workerData: 'user-password',
+});
 worker.on('message', hash => console.log('Computed hash:', hash));
 worker.on('error', err => console.error('Worker failed:', err));
 ```

--- a/pages/concurrency/comparing-nodejs-concurrency-models.md
+++ b/pages/concurrency/comparing-nodejs-concurrency-models.md
@@ -152,6 +152,12 @@ if (cluster.isPrimary) {
   }
 
   cluster.on('exit', (worker, code, signal) => {
+    if (worker.exitedAfterDisconnect) {
+      // A voluntary exit (e.g. worker.disconnect() or cluster.disconnect())
+      // — don't respawn.
+      return;
+    }
+
     console.log(`Worker ${worker.process.pid} died, restarting`);
     cluster.fork();
   });
@@ -165,7 +171,7 @@ if (cluster.isPrimary) {
 }
 ```
 
-The primary process (`cluster.isPrimary`) forks one worker per core and restarts any worker that exits unexpectedly. Each worker (`cluster.isWorker`) runs your normal server code, unaware that it's one of several.
+The primary process (`cluster.isPrimary`) forks one worker per core and restarts any worker that exits unexpectedly. Each worker (`cluster.isWorker`) runs your normal server code, unaware that it's one of several. The `worker.exitedAfterDisconnect` flag distinguishes a voluntary exit (e.g. during a graceful shutdown via `worker.disconnect()` or `cluster.disconnect()`) from a crash — without checking it, a deliberate shutdown would keep spawning new workers instead of winding down.
 
 ### How the workers share one port
 
@@ -178,7 +184,7 @@ Rather than relying on an OS-level mechanism, the primary process itself distrib
 ### Things to watch for
 
 - Workers are separate processes, so **they don't share memory**. In-memory sessions, caches, or rate limiters won't be visible across workers — use an external store like Redis for anything that needs to be shared.
-- Always handle a worker's `'exit'` event and decide whether to restart it; an unhandled crash silently reduces your server's capacity.
+- Always handle a worker's `'exit'` event and decide whether to restart it; an unhandled crash silently reduces your server's capacity. Check `worker.exitedAfterDisconnect` so a graceful shutdown doesn't get treated as a crash and endlessly respawn workers.
 - In production, most teams use a process manager (PM2, systemd, or a container orchestrator) instead of hand-rolling restart/reload logic with `cluster` directly.
 
 ## Choosing between them

--- a/pages/concurrency/comparing-nodejs-concurrency-models.md
+++ b/pages/concurrency/comparing-nodejs-concurrency-models.md
@@ -100,8 +100,7 @@ process.on('message', msg => {
 
 ### Example: offloading CPU-bound work
 
-```cjs
-// main.js
+```cjs displayName="main.js"
 const { Worker } = require('node:worker_threads');
 
 const worker = new Worker('./hash-worker.js', {
@@ -111,8 +110,7 @@ worker.on('message', hash => console.log('Computed hash:', hash));
 worker.on('error', err => console.error('Worker failed:', err));
 ```
 
-```cjs
-// hash-worker.js
+```cjs displayName="hash-worker.js"
 const { parentPort, workerData } = require('node:worker_threads');
 const { scryptSync, randomBytes } = require('node:crypto');
 

--- a/pages/concurrency/comparing-nodejs-concurrency-models.md
+++ b/pages/concurrency/comparing-nodejs-concurrency-models.md
@@ -1,0 +1,201 @@
+---
+authors: omscse
+---
+
+# Comparing Node.js concurrency models: Child Process, Worker Threads, and Cluster
+
+Node.js runs your JavaScript on a single thread, driven by the [event loop](/learn/asynchronous-work/event-loop-timers-and-nexttick). That model is great for I/O-bound work — reading files, querying a database, handling HTTP requests — because Node hands off the waiting to the operating system and keeps the thread free.
+
+It's a poor fit for two other situations, though:
+
+- **CPU-bound work** (image resizing, hashing, parsing huge payloads) ties up the single thread and makes your whole application unresponsive while it runs.
+- **Scaling across CPU cores** — a single Node.js process only ever uses one core for its JavaScript, no matter how many cores the machine has.
+
+Node.js ships three built-in modules to address this: [`child_process`](https://nodejs.org/api/child_process.html), [`worker_threads`](https://nodejs.org/api/worker_threads.html), and [`cluster`](https://nodejs.org/api/cluster.html). They solve overlapping problems in different ways, which is why it's easy to reach for the wrong one. This guide compares them side by side and walks through when to use each.
+
+## The three options at a glance
+
+|                  | Runs                                   | Isolation                                 | Communication                                             | Best for                                                                        |
+| ---------------- | -------------------------------------- | ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `child_process`  | A separate OS process (any executable) | Fully isolated, separate memory           | stdio streams, or IPC channel with `fork()`               | Running external programs, or another Node.js script that needs its own process |
+| `worker_threads` | A separate thread, same OS process     | Isolated by default, memory can be shared | `postMessage()`, or shared memory via `SharedArrayBuffer` | CPU-bound JavaScript that would otherwise block the event loop                  |
+| `cluster`        | Multiple full Node.js processes        | Fully isolated, separate memory           | IPC channel (built on `child_process`)                    | Scaling a network server (typically HTTP) across CPU cores                      |
+
+A useful way to tell them apart: `cluster` is built on top of `child_process` specifically to solve the "scale a server across cores" problem, while `worker_threads` exists to solve the "run CPU-heavy code without blocking" problem without paying the cost of a whole new process.
+
+## Child Process
+
+Use `child_process` when you need to run another program — a shell command, a binary, a script in another language — from Node.js, or when you want a fully isolated Node.js process that you drive over stdio/IPC.
+
+### `spawn`, `exec`, `execFile`, and `fork`
+
+| Method       | Description                                                                             | Use case                                                          |
+| ------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `spawn()`    | Launches a command and exposes stdout/stderr as streams                                 | Long-running processes, or output too large to buffer             |
+| `exec()`     | Runs a command through a shell and buffers the full output                              | Short commands with small output                                  |
+| `execFile()` | Like `exec()`, but runs a file directly without spawning a shell                        | Running a known binary/script safely, without shell interpolation |
+| `fork()`     | A specialized `spawn()` for running another Node.js module, with a built-in IPC channel | Parent/child communication between two Node.js processes          |
+
+`exec()` buffers the child's entire stdout/stderr in memory and only calls back once the process exits, with the result capped at 1 MiB (`maxBuffer`) by default — trying to capture a large or unbounded output this way will truncate it and terminate the child. `execFile()` avoids spawning a shell entirely, which also sidesteps shell-injection risks when part of the command comes from user input.
+
+### Example: streaming a long-running command with `spawn()`
+
+```cjs
+const { spawn } = require('node:child_process');
+
+const child = spawn('ffmpeg', ['-i', 'input.mp4', 'output.mp3']);
+
+child.stdout.on('data', data => console.log(`stdout: ${data}`));
+child.stderr.on('data', data => console.error(`stderr: ${data}`));
+child.on('close', code => console.log(`Process exited with code ${code}`));
+```
+
+```mjs
+import { spawn } from 'node:child_process';
+
+const child = spawn('ffmpeg', ['-i', 'input.mp4', 'output.mp3']);
+
+child.stdout.on('data', data => console.log(`stdout: ${data}`));
+child.stderr.on('data', data => console.error(`stderr: ${data}`));
+child.on('close', code => console.log(`Process exited with code ${code}`));
+```
+
+`spawn()` streams output as it's produced instead of buffering it, which is why it's the right choice for anything long-running or with unpredictable output size.
+
+### Example: talking to another Node.js process with `fork()`
+
+```cjs
+// parent.js
+const { fork } = require('node:child_process');
+
+const child = fork('./child.js');
+child.send({ task: 'start', data: 42 });
+child.on('message', result => console.log('Result from child:', result));
+```
+
+```cjs
+// child.js
+process.on('message', msg => {
+  console.log('Received from parent:', msg);
+  process.send('done');
+});
+```
+
+`fork()` gives you a ready-made, structured-clone-based IPC channel (`.send()` / `'message'`), so you don't have to parse stdout yourself the way you would with `spawn()`.
+
+### Things to watch for
+
+- Avoid `exec()` for anything that could produce a large output — use `spawn()` and stream it instead.
+- Always handle the `'exit'` and `'close'` events so you notice failures and clean up resources (open file descriptors, temporary files) instead of leaking them.
+- If any part of the command comes from user input, prefer `execFile()`/`spawn()` with an argument array over `exec()`, which runs through a shell and is vulnerable to shell injection if arguments aren't sanitized.
+
+## Worker Threads
+
+`worker_threads` was added to let you run JavaScript in parallel, in threads within the _same_ process, specifically to move CPU-bound work off the main thread without blocking it. Unlike `child_process`, workers share the same process — no OS-level process to spin up, and no fully separate memory space.
+
+|                  | Worker Threads                                         | Child Process                     |
+| ---------------- | ------------------------------------------------------ | --------------------------------- |
+| Context          | Same process                                           | Separate process                  |
+| Memory           | Isolated by default; can share via `SharedArrayBuffer` | Fully isolated                    |
+| Startup overhead | Low                                                    | Higher                            |
+| Communication    | `postMessage()` (structured clone, fast)               | stdio or IPC (serialized, slower) |
+
+### Example: offloading CPU-bound work
+
+```cjs
+// main.js
+const { Worker } = require('node:worker_threads');
+
+const worker = new Worker('./hash-worker.js', { workerData: 'user-password' });
+worker.on('message', hash => console.log('Computed hash:', hash));
+worker.on('error', err => console.error('Worker failed:', err));
+```
+
+```cjs
+// hash-worker.js
+const { parentPort, workerData } = require('node:worker_threads');
+const { scryptSync, randomBytes } = require('node:crypto');
+
+const salt = randomBytes(16);
+const hash = scryptSync(workerData, salt, 64).toString('hex');
+
+parentPort.postMessage(hash);
+```
+
+Password hashing, image/video transforms, encryption, and parsing very large in-memory payloads are classic candidates: they're pure CPU work, and running them on the main thread would stall every other request Node.js is handling in the meantime.
+
+### Sharing memory
+
+Workers can share memory directly using `SharedArrayBuffer` together with the `Atomics` API for safe concurrent access, instead of copying data back and forth with `postMessage()`. This avoids serialization overhead for large buffers, but you're now responsible for coordinating access yourself — it opens the door to the same race-condition class of bugs found in traditional multi-threaded programming.
+
+### Things to watch for
+
+- Worker threads are for CPU-bound work, not I/O — a worker still has to wait on I/O just like the main thread would, so spinning one up for a database call or a network request adds overhead for no benefit.
+- Spinning up a worker has a real cost. For small, frequent tasks, that setup overhead can outweigh the benefit — consider a pool of long-lived workers (see the [`workerpool`](https://www.npmjs.com/package/workerpool) package) instead of creating one per task.
+
+## Cluster
+
+`cluster` solves a different problem: a single Node.js process only uses one CPU core. To take advantage of a multi-core machine for a network server, `cluster` forks multiple full copies of your process (each one a `child_process` under the hood) that all listen on the same port.
+
+### Example: scaling an HTTP server across cores
+
+```cjs
+const cluster = require('node:cluster');
+const http = require('node:http');
+const { availableParallelism } = require('node:os');
+
+if (cluster.isPrimary) {
+  const numCPUs = availableParallelism();
+
+  for (let i = 0; i < numCPUs; i++) {
+    cluster.fork();
+  }
+
+  cluster.on('exit', (worker, code, signal) => {
+    console.log(`Worker ${worker.process.pid} died, restarting`);
+    cluster.fork();
+  });
+} else {
+  http
+    .createServer((req, res) => {
+      res.writeHead(200);
+      res.end('handled by worker ' + process.pid);
+    })
+    .listen(3000);
+}
+```
+
+The primary process (`cluster.isPrimary`) forks one worker per core and restarts any worker that exits unexpectedly. Each worker (`cluster.isWorker`) runs your normal server code, unaware that it's one of several.
+
+### How the workers share one port
+
+Rather than relying on an OS-level mechanism, the primary process itself distributes incoming connections to its workers — by default in a round-robin fashion (`cluster.SCHED_RR`), which is the default on every platform except Windows. This is configurable via `cluster.schedulingPolicy`. (You may see older material claim this is done via `SO_REUSEPORT`; that's not how Node's cluster module does it by default.)
+
+### `isPrimary` / `isWorker`
+
+`cluster.isPrimary` is `true` in the process that forks workers; `cluster.isWorker` is `true` in the forked workers themselves. (You may also see `cluster.isMaster` in older code — it still works, but it's a deprecated alias for `isPrimary`.)
+
+### Things to watch for
+
+- Workers are separate processes, so **they don't share memory**. In-memory sessions, caches, or rate limiters won't be visible across workers — use an external store like Redis for anything that needs to be shared.
+- Always handle a worker's `'exit'` event and decide whether to restart it; an unhandled crash silently reduces your server's capacity.
+- In production, most teams use a process manager (PM2, systemd, or a container orchestrator) instead of hand-rolling restart/reload logic with `cluster` directly.
+
+## Choosing between them
+
+A quick decision guide:
+
+- **Running an external program, or a script in another language?** → `child_process` (`spawn`/`execFile`).
+- **Running another Node.js script as an isolated process, with structured messaging?** → `child_process.fork()`.
+- **Have CPU-bound JavaScript blocking your event loop (hashing, image processing, big computations)?** → `worker_threads`.
+- **Want to use all the CPU cores to handle more traffic to your server?** → `cluster` (or a process manager/orchestrator that does the equivalent at the infrastructure level).
+
+These aren't mutually exclusive. A common pattern for something like an image-upload service is to combine all three: `cluster` to spread incoming requests across cores, and `worker_threads` (or `child_process`) within each worker to do the actual image processing without blocking that worker's event loop.
+
+## Further reading
+
+- [`child_process` API reference](https://nodejs.org/api/child_process.html)
+- [`worker_threads` API reference](https://nodejs.org/api/worker_threads.html)
+- [`cluster` API reference](https://nodejs.org/api/cluster.html)
+- [The Node.js Event Loop](/learn/asynchronous-work/event-loop-timers-and-nexttick)
+- [Don't Block the Event Loop](/learn/asynchronous-work/dont-block-the-event-loop)

--- a/pages/concurrency/comparing-nodejs-concurrency-models.md
+++ b/pages/concurrency/comparing-nodejs-concurrency-models.md
@@ -16,7 +16,7 @@ Node.js ships three built-in modules to address this: [`child_process`](https://
 ## The three options at a glance
 
 |                  | Runs               | Memory    | Talks via                | Best for                      |
-| ---------------- | ------------------ | --------- | ------------------------ | ----------------------------- |
+| :--------------- | :----------------- | :-------- | :----------------------- | :---------------------------- |
 | `child_process`  | Separate process   | Isolated  | stdio, or IPC (`fork()`) | Running external programs     |
 | `worker_threads` | Separate thread    | Shareable | `postMessage()`          | CPU-bound JS work             |
 | `cluster`        | Multiple processes | Isolated  | IPC                      | Scaling a server across cores |
@@ -30,7 +30,7 @@ Use `child_process` when you need to run another program — a shell command, a 
 ### `spawn`, `exec`, `execFile`, and `fork`
 
 | Method       | Description                                  | Use case                       |
-| ------------ | -------------------------------------------- | ------------------------------ |
+| :----------- | :------------------------------------------- | :----------------------------- |
 | `spawn()`    | Streams stdout/stderr                        | Long-running, large output     |
 | `exec()`     | Buffers full output via a shell              | Short commands, small output   |
 | `execFile()` | Like `exec()`, no shell                      | Running a known binary safely  |
@@ -94,7 +94,7 @@ process.on('message', msg => {
 `worker_threads` was added to let you run JavaScript in parallel, in threads within the _same_ process, specifically to move CPU-bound work off the main thread without blocking it. Unlike `child_process`, workers share the same process — no OS-level process to spin up, and no fully separate memory space.
 
 |                  | Worker Threads                    | Child Process         |
-| ---------------- | --------------------------------- | --------------------- |
+| :--------------- | :-------------------------------- | :-------------------- |
 | Context          | Same process                      | Separate process      |
 | Memory           | Shareable via `SharedArrayBuffer` | Isolated              |
 | Startup overhead | Low                               | Higher                |

--- a/pages/concurrency/comparing-nodejs-concurrency-models.md
+++ b/pages/concurrency/comparing-nodejs-concurrency-models.md
@@ -64,8 +64,7 @@ child.on('close', code => console.log(`Process exited with code ${code}`));
 
 ### Example: talking to another Node.js process with `fork()`
 
-```cjs
-// parent.js
+```cjs displayName="parent.js"
 const { fork } = require('node:child_process');
 
 const child = fork('./child.js');
@@ -73,8 +72,7 @@ child.send({ task: 'start', data: 42 });
 child.on('message', result => console.log('Result from child:', result));
 ```
 
-```cjs
-// child.js
+```cjs displayName="child.js"
 process.on('message', msg => {
   console.log('Received from parent:', msg);
   process.send('done');

--- a/pages/index.md
+++ b/pages/index.md
@@ -11,6 +11,7 @@ Welcome to the Node.js learning resources. Whether you're just getting started o
 - [HTTP](/learn/http/anatomy-of-an-http-transaction) — Build web servers and work with HTTP
 - [File System](/learn/manipulating-files/nodejs-file-stats) — Read, write, and manipulate files
 - [Asynchronous Work](/learn/asynchronous-work/javascript-asynchronous-programming-and-callbacks) — Understand async patterns, promises, and the event loop
+- [Concurrency](/learn/concurrency/comparing-nodejs-concurrency-models) — Compare child processes, worker threads, and cluster
 - [TypeScript](/learn/typescript/introduction) — Use TypeScript with Node.js
 - [Package Management](/learn/getting-started/an-introduction-to-the-npm-package-manager) — Publish and manage packages
 - [Diagnostics](/learn/diagnostics/user-journey) — Debug performance and memory issues

--- a/site.json
+++ b/site.json
@@ -291,6 +291,15 @@
       ]
     },
     {
+      "groupName": "Concurrency",
+      "items": [
+        {
+          "link": "/learn/concurrency/comparing-nodejs-concurrency-models",
+          "label": "Comparing Node.js concurrency models"
+        }
+      ]
+    },
+    {
       "groupName": "TypeScript",
       "items": [
         {


### PR DESCRIPTION
## Summary
- Adds a new **Concurrency** section to the Learn site with one article: *Comparing Node.js concurrency models*, covering `child_process`, `worker_threads`, and `cluster` side by side — comparison tables, runnable examples, and a decision guide for choosing between them.
- Updates `site.json` sidebar navigation and the `pages/index.md` homepage list to include the new section.
- Adds a row to `CONTRIBUTING.md`'s section table.

Closes #109

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes
- [x] `npm run build` — succeeds; verified generated HTML contains all expected headings and the homepage links to the new page